### PR TITLE
Lazy singleton

### DIFF
--- a/container.go
+++ b/container.go
@@ -14,21 +14,25 @@ func invoke(function interface{}) interface{} {
 
 // binding keeps a binding resolver and instance (for singleton bindings).
 type binding struct {
-	resolver interface{} // resolver function
-	instance interface{} // instance stored for singleton bindings
+	resolver  interface{} // resolver function
+	instance  interface{} // instance stored for singleton bindings
+	singleton bool
 }
 
 // resolve will return the concrete of related abstraction.
-func (b binding) resolve() interface{} {
-	if b.instance != nil {
+func (b *binding) resolve() interface{} {
+	if b.singleton {
+		if b.instance == nil {
+			b.instance = invoke(b.resolver)
+		}
 		return b.instance
 	}
 	return invoke(b.resolver)
 }
 
 // container is the IoC container that will keep all of the bindings.
-var container = map[reflect.Type]binding{}
-var containerPointer = map[reflect.Type]binding{}
+var container = map[reflect.Type]*binding{}
+var containerPointer = map[reflect.Type]*binding{}
 
 // bind will map an abstraction to a concrete and set instance if it's a singleton binding.
 func bind(resolver interface{}, singleton bool) {
@@ -38,20 +42,15 @@ func bind(resolver interface{}, singleton bool) {
 	}
 
 	for i := 0; i < resolverTypeOf.NumOut(); i++ {
-		var instance interface{}
-		if singleton {
-			instance = invoke(resolver)
-		}
-
 		if resolverTypeOf.Out(i).Kind() == reflect.Ptr {
-			containerPointer[resolverTypeOf.Out(i)] = binding{
-				resolver: resolver,
-				instance: instance,
+			containerPointer[resolverTypeOf.Out(i)] = &binding{
+				resolver:  resolver,
+				singleton: singleton,
 			}
 		} else {
-			container[resolverTypeOf.Out(i)] = binding{
-				resolver: resolver,
-				instance: instance,
+			container[resolverTypeOf.Out(i)] = &binding{
+				resolver:  resolver,
+				singleton: singleton,
 			}
 		}
 	}
@@ -115,8 +114,8 @@ func Transient(resolver interface{}) {
 
 // Reset will reset the container and remove all the bindings.
 func Reset() {
-	container = map[reflect.Type]binding{}
-	containerPointer = map[reflect.Type]binding{}
+	container = map[reflect.Type]*binding{}
+	containerPointer = map[reflect.Type]*binding{}
 }
 
 // Make will resolve the dependency and return a appropriate concrete of the given abstraction.
@@ -143,5 +142,3 @@ func Make(receiver interface{}) {
 
 	panic("the receiver must be either a reference or a callback")
 }
-
-

--- a/container.go
+++ b/container.go
@@ -8,14 +8,15 @@ import (
 
 // invoke will call the given function and return its returned value.
 // It only works for functions that return a single value.
-func invoke(function interface{}) interface{} {
-	return reflect.ValueOf(function).Call(arguments(function))[0].Interface()
+func invoke(function interface{}, functionType reflect.Type) interface{} {
+	return reflect.ValueOf(function).Call(arguments(functionType))[0].Interface()
 }
 
 // binding keeps a binding resolver and instance (for singleton bindings).
 type binding struct {
-	resolver interface{} // resolver function
-	instance interface{} // instance stored for singleton bindings
+	resolver     interface{} // resolver function
+	instance     interface{} // instance stored for singleton bindings
+	resolverType reflect.Type
 }
 
 // resolve will return the concrete of related abstraction.
@@ -23,12 +24,12 @@ func (b binding) resolve() interface{} {
 	if b.instance != nil {
 		return b.instance
 	}
-
-	return invoke(b.resolver)
+	return invoke(b.resolver, b.resolverType)
 }
 
 // container is the IoC container that will keep all of the bindings.
 var container = map[reflect.Type]binding{}
+var containerPointer = map[reflect.Type]binding{}
 
 // bind will map an abstraction to a concrete and set instance if it's a singleton binding.
 func bind(resolver interface{}, singleton bool) {
@@ -40,36 +41,63 @@ func bind(resolver interface{}, singleton bool) {
 	for i := 0; i < resolverTypeOf.NumOut(); i++ {
 		var instance interface{}
 		if singleton {
-			instance = invoke(resolver)
+			instance = invoke(resolver, resolverTypeOf)
 		}
 
-		container[resolverTypeOf.Out(i)] = binding{
-			resolver: resolver,
-			instance: instance,
+		if resolverTypeOf.Out(i).Kind() == reflect.Ptr {
+			containerPointer[resolverTypeOf.Out(i)] = binding{
+				resolver:     resolver,
+				instance:     instance,
+				resolverType: resolverTypeOf.Out(i),
+			}
+		} else {
+			container[resolverTypeOf.Out(i)] = binding{
+				resolver:     resolver,
+				instance:     instance,
+				resolverType: resolverTypeOf.Out(i),
+			}
 		}
 	}
 }
 
 // arguments will return resolved arguments of the given function.
-func arguments(function interface{}) []reflect.Value {
-	functionTypeOf := reflect.TypeOf(function)
+func arguments(functionTypeOf reflect.Type) []reflect.Value {
 	argumentsCount := functionTypeOf.NumIn()
 	arguments := make([]reflect.Value, argumentsCount)
 
 	for i := 0; i < argumentsCount; i++ {
 		abstraction := functionTypeOf.In(i)
 
-		var instance interface{}
+		var instance reflect.Value
 
-		if concrete, ok := container[abstraction]; ok {
-			instance = concrete.resolve()
+		if abstraction.Kind() == reflect.Ptr {
+			if concrete, ok := containerPointer[abstraction]; ok {
+				instance = reflect.ValueOf(concrete.resolve())
+			} else {
+				if concrete, ok := container[abstraction.Elem()]; ok {
+					//https://github.com/a8m/reflect-examples#wrap-a-reflectvalue-with-pointer-t--t
+					data := concrete.resolve()
+					pt := reflect.PtrTo(reflect.TypeOf(data)) // create a *T type.
+					pv := reflect.New(pt.Elem())  // create a reflect.Value of type *T.
+					pv.Elem().Set(reflect.ValueOf(data))              // sets pv to point to underlying value of v.
+					instance = pv
+				} else {
+					panic("no concrete found for the abstraction: " + abstraction.String())
+				}
+			}
 		} else {
-			panic("no concrete found for the abstraction: " + abstraction.String())
+			if concrete, ok := container[abstraction]; ok {
+				instance = reflect.ValueOf(concrete.resolve())
+			} else {
+				if concrete, ok := containerPointer[reflect.PtrTo(abstraction)]; ok {
+					instance = reflect.ValueOf(concrete.resolve()).Elem()
+				} else {
+					panic("no concrete found for the abstraction: " + abstraction.String())
+				}
+			}
 		}
-
-		arguments[i] = reflect.ValueOf(instance)
+		arguments[i] = instance
 	}
-
 	return arguments
 }
 
@@ -99,23 +127,47 @@ func Reset() {
 func Make(receiver interface{}) {
 	receiverTypeOf := reflect.TypeOf(receiver)
 	if receiverTypeOf == nil {
-		panic("cannot detect type of the receiver, make sure your are passing reference of the object")
+		panic("cannot detect type of the receiver, make sure your are passing reference of the object :")
 	}
 
 	if receiverTypeOf.Kind() == reflect.Ptr {
 		abstraction := receiverTypeOf.Elem()
 
-		if concrete, ok := container[abstraction]; ok {
-			instance := concrete.resolve()
-			reflect.ValueOf(receiver).Elem().Set(reflect.ValueOf(instance))
-			return
+		if abstraction.Kind() == reflect.Ptr {
+			if concrete, ok := containerPointer[abstraction]; ok {
+				instance := concrete.resolve()
+				reflect.ValueOf(receiver).Elem().Set(reflect.ValueOf(instance))
+				return
+			} else {
+				if concrete, ok := container[abstraction.Elem()]; ok {
+					instance := concrete.resolve()
+					field := reflect.New(reflect.TypeOf(instance))
+					field.Elem().Set(reflect.ValueOf(instance))
+					reflect.ValueOf(receiver).Elem().Set(field)
+					return
+				} else {
+					panic("no concrete found for the abstraction: " + abstraction.String())
+				}
+			}
+		} else {
+			if concrete, ok := container[abstraction]; ok {
+				instance := concrete.resolve()
+				reflect.ValueOf(receiver).Elem().Set(reflect.ValueOf(instance))
+				return
+			} else {
+				if concrete, ok := containerPointer[reflect.PtrTo(abstraction)]; ok {
+					instance := concrete.resolve()
+					reflect.ValueOf(receiver).Elem().Set(reflect.ValueOf(instance).Elem())
+					return
+				} else {
+					panic("no concrete found for the abstraction: " + abstraction.String())
+				}
+			}
 		}
-
-		panic("no concrete found for the abstraction " + abstraction.String())
 	}
 
 	if receiverTypeOf.Kind() == reflect.Func {
-		arguments := arguments(receiver)
+		arguments := arguments(receiverTypeOf)
 		reflect.ValueOf(receiver).Call(arguments)
 		return
 	}

--- a/container_test.go
+++ b/container_test.go
@@ -369,6 +369,14 @@ func TestMakeWithUnboundedAbstraction(t *testing.T) {
 		container.Make(&s)
 	}, "Expected panic")
 }
+func TestMakeWithUnboundedAbstractionPtr(t *testing.T) {
+	value := "no concrete found for the abstraction *container_test.Shape"
+	assert.PanicsWithValue(t, value, func() {
+		var s *Shape
+		container.Reset()
+		container.Make(&s)
+	}, "Expected panic")
+}
 
 func TestMakeWithCallbackThatHasAUnboundedAbstraction(t *testing.T) {
 	value := "no concrete found for the abstraction container_test.Database"

--- a/container_test.go
+++ b/container_test.go
@@ -371,7 +371,7 @@ func TestMakeWithUnboundedAbstraction(t *testing.T) {
 }
 
 func TestMakeWithCallbackThatHasAUnboundedAbstraction(t *testing.T) {
-	value := "no concrete found for the abstraction: container_test.Database"
+	value := "no concrete found for the abstraction container_test.Database"
 	assert.PanicsWithValue(t, value, func() {
 		container.Reset()
 		container.Singleton(func() Shape {

--- a/container_test.go
+++ b/container_test.go
@@ -33,6 +33,166 @@ func (m MySQL) Connect() bool {
 	return true
 }
 
+type Combined struct {
+	Cir *Circle
+	Db *MySQL
+}
+
+type Combined2 struct {
+	Cir Circle
+	Db *MySQL
+}
+
+func TestCombinedObject1(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() *Circle {
+		return &Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir *Circle, db *MySQL) *Combined{
+		return &Combined{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined *Combined
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
+func TestCombinedObject2(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() *Circle {
+		return &Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir *Circle, db *MySQL) *Combined{
+		return &Combined{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined Combined
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
+func TestCombinedObject3(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() *Circle {
+		return &Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir Circle, db *MySQL) *Combined2{
+		return &Combined2{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined Combined2
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
+func TestCombinedObject4(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() Circle {
+		return Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir *Circle, db *MySQL) *Combined{
+		return &Combined{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined Combined
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
+func TestCombinedObject5(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() *Circle {
+		return &Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir Circle, db *MySQL) Combined2{
+		return Combined2{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined *Combined2
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
+func TestCombinedObject6(t *testing.T) {
+	container.Reset()
+
+	container.Singleton(func() Circle {
+		return Circle{a:5}
+	})
+
+	container.Singleton(func() *MySQL {
+		return &MySQL{}
+	})
+
+	container.Singleton(func(cir *Circle, db *MySQL) Combined{
+		return Combined{
+			Cir: cir,
+			Db:  db,
+		}
+	})
+
+	var combined *Combined
+	container.Make(&combined)
+	assert.NotNil(t, combined)
+	assert.NotNil(t, combined.Cir)
+	assert.Equal(t, combined.Cir.a, 5)
+}
+
 func TestSingletonItShouldMakeAnInstanceOfTheAbstraction(t *testing.T) {
 	area := 5
 
@@ -187,6 +347,7 @@ func TestMakeWithMultipleInputsAndReference(t *testing.T) {
 func TestMakeWithUnsupportedReceiver(t *testing.T) {
 	value := "the receiver must be either a reference or a callback"
 	assert.PanicsWithValue(t, value, func() {
+		container.Reset()
 		container.Make("STRING!")
 	}, "Expected panic")
 }
@@ -195,6 +356,7 @@ func TestMakeWithNonReference(t *testing.T) {
 	value := "cannot detect type of the receiver, make sure your are passing reference of the object"
 	assert.PanicsWithValue(t, value, func() {
 		var s Shape
+		container.Reset()
 		container.Make(s)
 	}, "Expected panic")
 }


### PR DESCRIPTION
adding to the pointers commit, making singleton creation lazy. Keeping this as a different pull request merging this is choice. As if this is enabled, then when registering singleton, it does not check that the dependency have been registered, only during "make" is now that it fails for missing resolvers. I prefer it this way, but this creates a literal possibility of runtime panic during "make" now, as compared to during registration