### PR TITLE
support unexported fields

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"unsafe"
 )
 
 // binding keeps a binding resolver and an instance (for singleton bindings).
@@ -201,7 +202,9 @@ func (c Container) Fill(structure interface{}) error {
 							return err
 						}
 
-						f.Set(reflect.ValueOf(instance))
+						// support also unexported fields
+						ptr := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+						ptr.Set(reflect.ValueOf(instance))
 
 						continue
 					}

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -295,6 +295,30 @@ func TestContainer_Fill_With_Struct_Pointer(t *testing.T) {
 	assert.IsType(t, &MySQL{}, myApp.D)
 }
 
+func TestContainer_FillUnexported_With_Struct_Pointer(t *testing.T) {
+	err := instance.Singleton(func() Shape {
+		return &Circle{a: 5}
+	})
+	assert.NoError(t, err)
+
+	err = instance.Singleton(func() Database {
+		return &MySQL{}
+	})
+	assert.NoError(t, err)
+
+	myApp := struct {
+		s Shape    `container:"inject"`
+		d Database `container:"inject"`
+		X string
+	}{}
+
+	err = instance.Fill(&myApp)
+	assert.NoError(t, err)
+
+	assert.IsType(t, &Circle{}, myApp.s)
+	assert.IsType(t, &MySQL{}, myApp.d)
+}
+
 func TestContainer_Fill_With_Invalid_Field_It_Should_Fail(t *testing.T) {
 	type App struct {
 		S string `container:"inject"`


### PR DESCRIPTION
The current implementation doesn't support unexported fields. While trying to `Fill` a struct with tagged unexported field we get:

```
panic: reflect: reflect.Value.Set using value obtained using unexported field [recovered]
        panic: reflect: reflect.Value.Set using value obtained using unexported field
```

I think it's required to support such fields. Very often we don't want to expose struct fields like database and hide it as the internal definition injected by the framework.

This pull-request adds such support. The added test is basically the same as the exiting one, but with unexported fields.