### PR TITLE
Add support for slices and maps in Fill()

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,20 @@ err := container.Fill(&myApp)
 // `myApp.x` will be ignored since it has no `container` tag
 ```
 
+Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementation of provided Type.
+
+```go
+var list []Shape
+container.Fill(&list)
+
+// []Shape{&Rectangle{}, &Circle{}}
+
+var list map[string]Shape
+container.Fill(&list)
+
+// map[string]Shape{"square": &Rectangle{}, "rounded": &Circle{}} 
+```
+
 #### Binding time
 You can resolve dependencies at the binding time if you need previous dependencies for the new one.
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ err := container.Fill(&myApp)
 // `myApp.x` will be ignored since it has no `container` tag
 ```
 
-Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementation of provided Type.
+Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementations of provided Type.
 
 ```go
 var list []Shape

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -170,7 +170,7 @@ func (c Container) NamedResolve(abstraction interface{}, name string) error {
 }
 
 // Fill takes a struct and resolves the fields with the tag `container:"inject"`.
-// Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementation of provided Type.
+// Alternatively map[string]Type or []Type can be provided. It will be filled with all available implementations of provided Type.
 func (c Container) Fill(receiver interface{}) error {
 	receiverType := reflect.TypeOf(receiver)
 	if receiverType == nil {

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -201,8 +201,8 @@ func (c Container) Fill(receiver interface{}) error {
 	return errors.New("container: invalid receiver")
 }
 
-func (c Container) fillStruct(structure interface{}) error {
-	s := reflect.ValueOf(structure).Elem()
+func (c Container) fillStruct(receiver interface{}) error {
+	s := reflect.ValueOf(receiver).Elem()
 
 	for i := 0; i < s.NumField(); i++ {
 		f := s.Field(i)
@@ -236,8 +236,8 @@ func (c Container) fillStruct(structure interface{}) error {
 	return nil
 }
 
-func (c Container) fillSlice(structure interface{}) error {
-	elem := reflect.TypeOf(structure).Elem()
+func (c Container) fillSlice(receiver interface{}) error {
+	elem := reflect.TypeOf(receiver).Elem()
 
 	if _, exist := c[elem.Elem()]; exist {
 		result := reflect.MakeSlice(reflect.SliceOf(elem.Elem()), 0, len(c[elem.Elem()]))
@@ -248,14 +248,14 @@ func (c Container) fillSlice(structure interface{}) error {
 			result = reflect.Append(result, reflect.ValueOf(instance))
 		}
 
-		reflect.ValueOf(structure).Elem().Set(result)
+		reflect.ValueOf(receiver).Elem().Set(result)
 	}
 
 	return nil
 }
 
-func (c Container) fillMap(structure interface{}) error {
-	elem := reflect.TypeOf(structure).Elem()
+func (c Container) fillMap(receiver interface{}) error {
+	elem := reflect.TypeOf(receiver).Elem()
 
 	if _, exist := c[elem.Elem()]; exist {
 		result := reflect.MakeMapWithSize(reflect.MapOf(elem.Key(), elem.Elem()), len(c[elem.Elem()]))
@@ -266,7 +266,7 @@ func (c Container) fillMap(structure interface{}) error {
 			result.SetMapIndex(reflect.ValueOf(name), reflect.ValueOf(instance))
 		}
 
-		reflect.ValueOf(structure).Elem().Set(result)
+		reflect.ValueOf(receiver).Elem().Set(result)
 	}
 
 	return nil

--- a/pkg/container/container_test.go
+++ b/pkg/container/container_test.go
@@ -282,6 +282,16 @@ func TestContainer_Fill_Unexported_With_Struct_Pointer(t *testing.T) {
 	assert.IsType(t, &MySQL{}, myApp.d)
 }
 
+func TestContainer_Fill_Without_Pointer(t *testing.T) {
+	err := instance.Singleton(func() Shape {
+		return &Circle{a: 5}
+	})
+	assert.NoError(t, err)
+
+	var db MySQL
+	assert.EqualError(t, instance.Fill(db), "container: receiver is not a pointer")
+}
+
 func TestContainer_Fill_With_Invalid_Field_It_Should_Fail(t *testing.T) {
 	err := instance.NamedSingleton("C", func() Shape {
 		return &Circle{a: 5}
@@ -330,6 +340,16 @@ func TestContainer_Fill_With_Invalid_Pointer_It_Should_Fail(t *testing.T) {
 	var s Shape
 	err := instance.Fill(s)
 	assert.EqualError(t, err, "container: invalid receiver")
+}
+
+func TestContainer_Fill_Invalid_Map(t *testing.T) {
+	err := instance.Singleton(func() Shape {
+		return &Circle{a: 5}
+	})
+	assert.NoError(t, err)
+
+	var list = map[int]Shape{}
+	assert.EqualError(t, instance.Fill(&list), "container: invalid receiver")
 }
 
 func TestContainer_Fill_With_Slice(t *testing.T) {


### PR DESCRIPTION
Fill() in addition to structs now alternatively supports map[string]Type and []Type. It will be filled with all available implementations of provided Type.

```go
var list []Shape
container.Fill(&list)
// []Shape{&Rectangle{}, &Circle{}}

var list map[string]Shape
container.Fill(&list)
// map[string]Shape{"square": &Rectangle{}, "rounded": &Circle{}} 
```
