### PR TITLE
added generic ResolveT and "must" methods

### DIFF
--- a/container.go
+++ b/container.go
@@ -201,7 +201,15 @@ func (c Container) Call(function interface{}) error {
 		return err
 	}
 
-	reflect.ValueOf(function).Call(arguments)
+	result := reflect.ValueOf(function).Call(arguments)
+
+	// if the receiver returns an error then we'll forward
+	// the return value as the Call() result.
+	if len(result) == 1 && result[0].CanInterface() {
+		if err, ok := result[0].Interface().(error); ok {
+			return err
+		}
+	}
 
 	return nil
 }

--- a/generics.go
+++ b/generics.go
@@ -1,0 +1,24 @@
+//go:build go1.18
+
+package container
+
+func ResolveT[T any](c Container) (T, error) {
+	var defaultvalue T
+
+	if err := c.Resolve(&defaultvalue); err != nil {
+		return defaultvalue, err
+	}
+
+	return defaultvalue, nil
+}
+
+func MustResolveT[T any](c Container) T {
+	return must(ResolveT[T](c))
+}
+
+func must[T any](value T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return value
+}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,11 @@
 module github.com/golobby/container/v3
 
-go 1.11
+go 1.18
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/must.go
+++ b/must.go
@@ -1,0 +1,31 @@
+package container
+
+func MustSingleton(c Container, resolver interface{}) {
+	if err := c.Singleton(resolver); err != nil {
+		panic(err)
+	}
+}
+
+func MustNamedSingleton(c Container, name string, resolver interface{}) {
+	if err := c.NamedSingleton(name, resolver); err != nil {
+		panic(err)
+	}
+}
+
+func MustTransient(c Container, resolver interface{}) {
+	if err := c.Transient(resolver); err != nil {
+		panic(err)
+	}
+}
+
+func MustNamedTransient(c Container, name string, resolver interface{}) {
+	if err := c.NamedTransient(name, resolver); err != nil {
+		panic(err)
+	}
+}
+
+func MustCall(c Container, receiver interface{}) {
+	if err := c.Call(receiver); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
This PR adds the following methods:

```golang
c := container.New()

db, err := container.ResolveT[Database](c)
if err != nil {
    // error
}

db := container.MustResolveT[Database](c)

container.MustSingleton(c, resolver)
container.MustNamedSingleton(c, "", resolver)
container.MustTransient(c, resolver)
container.MustNamedTransient(c, "", resolver)
container.MustCall(c, receiver)
```