### PR TITLE
Adding support of binding as a struct but resolving as an interface

### DIFF
--- a/container.go
+++ b/container.go
@@ -117,7 +117,7 @@ func (c Container) arguments(function interface{}) ([]reflect.Value, error) {
 
 	for i := 0; i < argumentsCount; i++ {
 		abstraction := reflectedFunction.In(i)
-		if concrete, exist := c[abstraction][""]; exist {
+		if concrete, exist := c.concrete(abstraction); exist {
 			instance, err := concrete.make(c)
 			if err != nil {
 				return nil, err
@@ -129,6 +129,19 @@ func (c Container) arguments(function interface{}) ([]reflect.Value, error) {
 	}
 
 	return arguments, nil
+}
+
+func (c Container) concrete(abstraction reflect.Type) (*binding, bool) {
+	if concrete, exist := c[abstraction][""]; exist {
+		return concrete, true
+	}
+	for boundAbstraction, namedConcretes := range c {
+		if boundAbstraction.Implements(abstraction) {
+			concrete, exists := namedConcretes[""]
+			return concrete, exists
+		}
+	}
+	return nil, false
 }
 
 // Reset deletes all the existing bindings and empties the container.

--- a/container_test.go
+++ b/container_test.go
@@ -13,6 +13,10 @@ type Shape interface {
 	GetArea() int
 }
 
+type ReadOnlyShape interface {
+	GetArea() int
+}
+
 type Circle struct {
 	a int
 }
@@ -51,6 +55,28 @@ func TestContainer_Singleton(t *testing.T) {
 	err = instance.Call(func(s2 Shape) {
 		a := s2.GetArea()
 		assert.Equal(t, a, 666)
+	})
+	assert.NoError(t, err)
+}
+
+func TestContainer_Singleton_Bind_As_Struct_But_Resolve_By_Interface(t *testing.T) {
+	instance := container.New()
+
+	err := instance.Singleton(func() *Circle {
+		return &Circle{a: 13}
+	})
+	assert.NoError(t, err)
+
+	err = instance.Call(func(s Shape) {
+		a := s.GetArea()
+		assert.Equal(t, 13, a)
+		s.SetArea(666)
+	})
+	assert.NoError(t, err)
+
+	err = instance.Call(func(s ReadOnlyShape) {
+		a := s.GetArea()
+		assert.Equal(t, 666, a)
 	})
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
Hi!
First of all, thank your hard work and for this excellent container!

I've added support for instances resolving by an interface, even if they were bound as structs.
We need this as we are trying to make a library that provides different receiver functions. The library knows nothing about containers and uses locally created interfaces about whose the client application knows nothing too. But the client application creates a container with different bound objects that will be used to fill in these resolve functions from the library.
Not sure if my motivation is clear, but I hope so. I can add more details. I would very much appreciate merging this.
