### PR TITLE
Adds descriptive error when failing to make concrete

### DIFF
--- a/container.go
+++ b/container.go
@@ -239,7 +239,7 @@ func (c Container) NamedResolve(abstraction interface{}, name string) error {
 				reflect.ValueOf(abstraction).Elem().Set(reflect.ValueOf(instance))
 				return nil
 			} else {
-				return err
+				return fmt.Errorf("container: encountered error while making concrete for: %s. Error encountered: %w", elem.String(), err)
 			}
 		}
 


### PR DESCRIPTION
If using lazy loading and the call to a resolver when making a concrete fails, that error wasn't wrapped and caused confusion since we didn't know which abstraction we were attempting to satisfy.

Wrapping error so we know that:
  a) Error occurred during resolve call.
  b) What abstraction we were trying to resolve.

This should make it easier to debug these failures in lazy loading situations.